### PR TITLE
Reexport filesystems from go git

### DIFF
--- a/memory/memory.go
+++ b/memory/memory.go
@@ -1,0 +1,11 @@
+package memory
+
+import (
+	"gopkg.in/src-d/go-git.v4/utils/fs/memory"
+
+	"srcd.works/billy"
+)
+
+func New() billy.Filesystem {
+	return memory.New()
+}

--- a/memory/memory_test.go
+++ b/memory/memory_test.go
@@ -1,0 +1,17 @@
+package memory_test
+
+import (
+	"srcd.works/billy"
+	"srcd.works/billy/memory"
+)
+
+func Example() {
+	var fs billy.Filesystem
+	fs = memory.New()
+
+	doSomethingWith(fs)
+}
+
+func doSomethingWith(fs billy.Filesystem) {
+	// Intentionally left blank
+}

--- a/os/os.go
+++ b/os/os.go
@@ -1,0 +1,11 @@
+package os
+
+import (
+	"gopkg.in/src-d/go-git.v4/utils/fs/os"
+
+	"srcd.works/billy"
+)
+
+func New(baseDir string) billy.Filesystem {
+	return os.New(baseDir)
+}

--- a/os/os_test.go
+++ b/os/os_test.go
@@ -1,0 +1,17 @@
+package os_test
+
+import (
+	"srcd.works/billy"
+	"srcd.works/billy/os"
+)
+
+func Example() {
+	var fs billy.Filesystem
+	fs = os.New("/bin")
+
+	doSomethingWith(fs)
+}
+
+func doSomethingWith(fs billy.Filesystem) {
+	// Intentionally left blank
+}


### PR DESCRIPTION
I need some help with this. What is the best way to _reexport_ structs in Go while making sure they are compatible? Is there any way to do so?

Any elegant way I found was to just make the `New` function return a `billy.Filesystem` but that is not the way go-git does it.

Input much appreaciated.