### PR TITLE
memfs: Fix memory FS implementation bug

### DIFF
--- a/memfs/memory.go
+++ b/memfs/memory.go
@@ -282,7 +282,7 @@ func (f *file) Seek(offset int64, whence int) (int64, error) {
 	case io.SeekStart:
 		f.position = offset
 	case io.SeekEnd:
-		f.position = int64(f.content.Len()) - offset
+		f.position = int64(f.content.Len()) + offset
 	}
 
 	return f.position, nil
@@ -368,6 +368,12 @@ type content struct {
 
 func (c *content) WriteAt(p []byte, off int64) (int, error) {
 	prev := len(c.bytes)
+
+	diff := int(off) - prev
+	if diff > 0 {
+		c.bytes = append(c.bytes, make([]byte, diff)...)
+	}
+
 	c.bytes = append(c.bytes[:off], p...)
 	if len(c.bytes) < prev {
 		c.bytes = c.bytes[:prev]

--- a/test/fs_suite.go
+++ b/test/fs_suite.go
@@ -142,6 +142,26 @@ func (s *FilesystemSuite) TestOpenFileReadWrite(c *C) {
 	s.testReadClose(c, f, "quxbar")
 }
 
+func (s *FilesystemSuite) TestSeekToEndAndWrite(c *C) {
+	defaultMode := os.FileMode(0666)
+
+	f, err := s.FS.OpenFile("foo1", os.O_CREATE|os.O_TRUNC|os.O_RDWR, defaultMode)
+	c.Assert(err, IsNil)
+	c.Assert(f.Filename(), Equals, "foo1")
+
+	_, err = f.Seek(10, io.SeekEnd)
+	c.Assert(err, IsNil)
+
+	n, err := f.Write([]byte(`TEST`))
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, 4)
+
+	_, err = f.Seek(0, io.SeekStart)
+	c.Assert(err, IsNil)
+
+	s.testReadClose(c, f, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00TEST")
+}
+
 func (s *FilesystemSuite) TestOpenFile(c *C) {
 	defaultMode := os.FileMode(0666)
 


### PR DESCRIPTION
Now, using memory FS, is possible to seek outside the size of the file and write something, adding '0' between the old file content and the new one.