### PR TITLE
memfs: bug fixing

### DIFF
--- a/memfs/memory.go
+++ b/memfs/memory.go
@@ -170,8 +170,10 @@ type file struct {
 
 func (f *file) Read(b []byte) (int, error) {
 	n, err := f.ReadAt(b, f.position)
-	if err != nil {
-		return 0, err
+	f.position += int64(n)
+
+	if err == io.EOF && n != 0 {
+		err = nil
 	}
 
 	return n, err
@@ -187,7 +189,6 @@ func (f *file) ReadAt(b []byte, off int64) (int, error) {
 	}
 
 	n, err := f.content.ReadAt(b, off)
-	f.position += int64(n)
 
 	return n, err
 }

--- a/memfs/storage.go
+++ b/memfs/storage.go
@@ -185,7 +185,7 @@ func (c *content) WriteAt(p []byte, off int64) (int, error) {
 	return len(p), nil
 }
 
-func (c *content) ReadAt(b []byte, off int64) (int, error) {
+func (c *content) ReadAt(b []byte, off int64) (n int, err error) {
 	size := int64(len(c.bytes))
 	if off >= size {
 		return 0, io.EOF
@@ -196,6 +196,11 @@ func (c *content) ReadAt(b []byte, off int64) (int, error) {
 		l = size - off
 	}
 
-	n := copy(b, c.bytes[off:off+l])
-	return n, nil
+	btr := c.bytes[off : off+l]
+	if len(btr) < len(b) {
+		err = io.EOF
+	}
+	n = copy(b, btr)
+
+	return
 }


### PR DESCRIPTION
In this PR we fix two different bugs in memfs implementation:

- Using ReadAt, if the provided slice of bytes has a size bigger than the data to read, it must return the result and a io.EOF error.
- ReadAt must not affect to the offset position: https://golang.org/src/io/io.go?s=7545:7620#L203