### PR TITLE
memfs: fix Rename leftovers

### DIFF
--- a/memfs/storage.go
+++ b/memfs/storage.go
@@ -139,8 +139,11 @@ func (s *storage) move(from, to string) error {
 	s.files[to].BaseFilename = filepath.Base(to)
 	s.children[to] = s.children[from]
 
-	delete(s.children, from)
-	delete(s.files, from)
+	defer func() {
+		delete(s.children, from)
+		delete(s.files, from)
+		delete(s.children[filepath.Dir(from)], filepath.Base(from))
+	}()
 
 	return s.createParent(to, 0644, s.files[to])
 }

--- a/test/fs_suite.go
+++ b/test/fs_suite.go
@@ -523,6 +523,10 @@ func (s *FilesystemSuite) TestRename(c *C) {
 	err := WriteFile(s.FS, "foo", nil, 0644)
 	c.Assert(err, IsNil)
 
+	files, err := s.FS.ReadDir("")
+	c.Assert(err, IsNil)
+	c.Assert(files, HasLen, 1)
+
 	err = s.FS.Rename("foo", "bar")
 	c.Assert(err, IsNil)
 
@@ -531,8 +535,12 @@ func (s *FilesystemSuite) TestRename(c *C) {
 	c.Assert(os.IsNotExist(err), Equals, true)
 
 	bar, err := s.FS.Stat("bar")
-	c.Assert(bar, NotNil)
 	c.Assert(err, IsNil)
+	c.Assert(bar, NotNil)
+
+	files, err = s.FS.ReadDir("")
+	c.Assert(err, IsNil)
+	c.Assert(files, HasLen, 1)
 }
 
 func (s *FilesystemSuite) TestRenameToDir(c *C) {


### PR DESCRIPTION
In memfs when a file was move, a leftover was left inside of the storage, this cause that ReadDir, returns two entries for the same moved file.