### PR TITLE
Implement partial symlink support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/coverage.txt

--- a/fs.go
+++ b/fs.go
@@ -42,6 +42,13 @@ type Filesystem interface {
 	Base() string
 }
 
+// Symlinker is a Filesystem with support for creating symlinks.
+type Symlinker interface {
+	Filesystem
+	Symlink(oldname, newname string) error
+	Readlink(name string) (string, error)
+}
+
 // File implements io.Closer, io.Reader, io.Seeker, and io.Writer>
 // Provides method to obtain the file name and the state of the file (open or closed).
 type File interface {

--- a/fs.go
+++ b/fs.go
@@ -45,8 +45,15 @@ type Filesystem interface {
 // Symlinker is a Filesystem with support for creating symlinks.
 type Symlinker interface {
 	Filesystem
-	Symlink(oldname, newname string) error
-	Readlink(name string) (string, error)
+
+	// Symlink creates a symbolic-link from link to target. target may be an
+	// absolute or relative path, and need not refer to an existing node.
+	// Parent directories of link are created as necessary.
+	Symlink(target, link string) error
+
+	// Readlink returns the target path of link. An error is returned if link is
+	// not a symbolic-link.
+	Readlink(link string) (string, error)
 }
 
 // File implements io.Closer, io.Reader, io.Seeker, and io.Writer>

--- a/osfs/os.go
+++ b/osfs/os.go
@@ -169,6 +169,7 @@ func (fs *OS) RemoveAll(path string) error {
 }
 
 // Symlink creates name as a symbolic link to oldname.
+// All parent directories are created.
 func (fs *OS) Symlink(oldname, newname string) error {
 	if filepath.IsAbs(oldname) {
 		// only rewrite oldname if it's already absolute

--- a/osfs/os.go
+++ b/osfs/os.go
@@ -168,7 +168,7 @@ func (fs *OS) RemoveAll(path string) error {
 	return os.RemoveAll(fullpath)
 }
 
-// Symlink creates name as a symbolic link to oldname.
+// Symlink creates newname as a symbolic link to oldname.
 // All parent directories are created.
 func (fs *OS) Symlink(oldname, newname string) error {
 	if filepath.IsAbs(oldname) {

--- a/osfs/os.go
+++ b/osfs/os.go
@@ -168,25 +168,24 @@ func (fs *OS) RemoveAll(path string) error {
 	return os.RemoveAll(fullpath)
 }
 
-// Symlink creates newname as a symbolic link to oldname.
-// All parent directories are created.
-func (fs *OS) Symlink(oldname, newname string) error {
-	if filepath.IsAbs(oldname) {
-		// only rewrite oldname if it's already absolute
-		oldname = fs.Join(fs.base, oldname)
+// Symlink imlements billy.Symlinker.Symlink.
+func (fs *OS) Symlink(target, link string) error {
+	if filepath.IsAbs(target) {
+		// only rewrite target if it's already absolute
+		target = fs.Join(fs.base, target)
 	}
-	newname = fs.Join(fs.base, newname)
+	link = fs.Join(fs.base, link)
 
-	if err := fs.createDir(newname); err != nil {
+	if err := fs.createDir(link); err != nil {
 		return err
 	}
 
-	return os.Symlink(oldname, newname)
+	return os.Symlink(target, link)
 }
 
-// Readlink returns the destination of the named symbolic link.
-func (fs *OS) Readlink(name string) (string, error) {
-	fullpath := fs.Join(fs.base, name)
+// Readlink implements billy.Symlinker.Readlink.
+func (fs *OS) Readlink(link string) (string, error) {
+	fullpath := fs.Join(fs.base, link)
 	target, err := os.Readlink(fullpath)
 	if err != nil {
 		return "", err

--- a/osfs/os.go
+++ b/osfs/os.go
@@ -170,15 +170,32 @@ func (fs *OS) RemoveAll(path string) error {
 
 // Symlink creates name as a symbolic link to oldname.
 func (fs *OS) Symlink(oldname, newname string) error {
-	fullpath := fs.Join(fs.base, newname)
-	// oldname is not joined to the base to allow relative symlink targets
-	return os.Symlink(oldname, fullpath)
+	if filepath.IsAbs(oldname) {
+		// only rewrite oldname if it's already absolute
+		oldname = fs.Join(fs.base, oldname)
+	}
+	newname = fs.Join(fs.base, newname)
+	return os.Symlink(oldname, newname)
 }
 
 // Readlink returns the destination of the named symbolic link.
 func (fs *OS) Readlink(name string) (string, error) {
 	fullpath := fs.Join(fs.base, name)
-	return os.Readlink(fullpath)
+	target, err := os.Readlink(fullpath)
+	if err != nil {
+		return "", err
+	}
+
+	if !filepath.IsAbs(target) {
+		return target, nil
+	}
+
+	target, err = filepath.Rel(fs.base, target)
+	if err != nil {
+		return "", err
+	}
+
+	return string(os.PathSeparator) + target, nil
 }
 
 // osFile represents a file in the os filesystem

--- a/osfs/os.go
+++ b/osfs/os.go
@@ -168,6 +168,19 @@ func (fs *OS) RemoveAll(path string) error {
 	return os.RemoveAll(fullpath)
 }
 
+// Symlink creates name as a symbolic link to oldname.
+func (fs *OS) Symlink(oldname, newname string) error {
+	fullpath := fs.Join(fs.base, newname)
+	// oldname is not joined to the base to allow relative symlink targets
+	return os.Symlink(oldname, fullpath)
+}
+
+// Readlink returns the destination of the named symbolic link.
+func (fs *OS) Readlink(name string) (string, error) {
+	fullpath := fs.Join(fs.base, name)
+	return os.Readlink(fullpath)
+}
+
 // osFile represents a file in the os filesystem
 type osFile struct {
 	billy.BaseFile

--- a/osfs/os.go
+++ b/osfs/os.go
@@ -1,4 +1,4 @@
-// Package os provides a billy filesystem for the OS.
+// Package osfs provides a billy filesystem for the OS.
 package osfs // import "gopkg.in/src-d/go-billy.v2/osfs"
 
 import (
@@ -175,6 +175,11 @@ func (fs *OS) Symlink(oldname, newname string) error {
 		oldname = fs.Join(fs.base, oldname)
 	}
 	newname = fs.Join(fs.base, newname)
+
+	if err := fs.createDir(newname); err != nil {
+		return err
+	}
+
 	return os.Symlink(oldname, newname)
 }
 

--- a/subdirfs/subdir.go
+++ b/subdirfs/subdir.go
@@ -120,6 +120,7 @@ func (s *subdirFs) Base() string {
 }
 
 // Symlink creates name as a symbolic link to oldname.
+// All parent directories are created.
 func (s *subdirFs) Symlink(oldname, newname string) error {
 	fs, ok := s.underlying.(billy.Symlinker)
 	if !ok {

--- a/subdirfs/subdir.go
+++ b/subdirfs/subdir.go
@@ -119,30 +119,29 @@ func (s *subdirFs) Base() string {
 	return s.base
 }
 
-// Symlink creates newname as a symbolic link to oldname.
-// All parent directories are created.
-func (s *subdirFs) Symlink(oldname, newname string) error {
+// Symlink implements billy.Symlinker.Symlink.
+func (s *subdirFs) Symlink(target, link string) error {
 	fs, ok := s.underlying.(billy.Symlinker)
 	if !ok {
 		return ErrSymlinkNotSupported
 	}
 
-	if filepath.IsAbs(oldname) {
-		// only rewrite oldname if it's already absolute
-		oldname = string(os.PathSeparator) + s.underlyingPath(oldname)
+	if filepath.IsAbs(target) {
+		// only rewrite target if it's already absolute
+		target = string(os.PathSeparator) + s.underlyingPath(target)
 	}
-	newname = s.underlyingPath(newname)
-	return fs.Symlink(oldname, newname)
+	link = s.underlyingPath(link)
+	return fs.Symlink(target, link)
 }
 
-// Readlink returns the destination of the named symbolic link.
-func (s *subdirFs) Readlink(name string) (string, error) {
+// Readlink implements billy.Symlinker.Readlink.
+func (s *subdirFs) Readlink(link string) (string, error) {
 	fs, ok := s.underlying.(billy.Symlinker)
 	if !ok {
 		return "", ErrSymlinkNotSupported
 	}
 
-	fullpath := s.underlyingPath(name)
+	fullpath := s.underlyingPath(link)
 	target, err := fs.Readlink(fullpath)
 	if err != nil {
 		return "", err

--- a/subdirfs/subdir.go
+++ b/subdirfs/subdir.go
@@ -119,7 +119,7 @@ func (s *subdirFs) Base() string {
 	return s.base
 }
 
-// Symlink creates name as a symbolic link to oldname.
+// Symlink creates newname as a symbolic link to oldname.
 // All parent directories are created.
 func (s *subdirFs) Symlink(oldname, newname string) error {
 	fs, ok := s.underlying.(billy.Symlinker)

--- a/subdirfs/subdir_test.go
+++ b/subdirfs/subdir_test.go
@@ -38,3 +38,17 @@ func (s *FilesystemSuite) TearDownTest(c *C) {
 	err = stdos.RemoveAll(s.path)
 	c.Assert(err, IsNil)
 }
+
+func (s *FilesystemSuite) TestSymlinkWithNoUnderlyingSupport(c *C) {
+	s.cfs.(*subdirFs).underlying = nil
+
+	err := s.cfs.(billy.Symlinker).Symlink("foo", "bar")
+	c.Assert(err, Equals, ErrSymlinkNotSupported)
+}
+
+func (s *FilesystemSuite) TestReadlinkWithNoUnderlyingSupport(c *C) {
+	s.cfs.(*subdirFs).underlying = nil
+
+	_, err := s.cfs.(billy.Symlinker).Readlink("foo")
+	c.Assert(err, Equals, ErrSymlinkNotSupported)
+}

--- a/test/fs_suite.go
+++ b/test/fs_suite.go
@@ -1135,3 +1135,16 @@ func (s *FilesystemSuite) TestReadlinkWithNonExistentLink(c *C) {
 	_, err := fs.Readlink("link")
 	c.Assert(os.IsNotExist(err), Equals, true)
 }
+
+func (s *FilesystemSuite) TestReadlinkWithRegularFile(c *C) {
+	fs, ok := s.FS.(Symlinker)
+	if !ok {
+		c.Skip("file system does not support symlinking")
+	}
+
+	err := WriteFile(fs, "file", nil, 0644)
+	c.Assert(err, IsNil)
+
+	_, err = fs.Readlink("file")
+	c.Assert(err, ErrorMatches, "readlink .+/file: invalid argument")
+}

--- a/test/fs_suite.go
+++ b/test/fs_suite.go
@@ -936,6 +936,7 @@ func (s *FilesystemSuite) TestSymlink(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(fi.Name(), Equals, "link")
 	c.Assert(fi.Mode()&os.ModeSymlink, Not(Equals), 0)
+	c.Assert(fi.Size(), Equals, int64(0))
 }
 
 func (s *FilesystemSuite) TestSymlinkToDir(c *C) {
@@ -980,7 +981,7 @@ func (s *FilesystemSuite) TestSymlinkWithExistingNewname(c *C) {
 	c.Assert(err, IsNil)
 
 	err = fs.Symlink("file", "link")
-	c.Assert(err, ErrorMatches, "symlink file .+/link: file exists")
+	c.Assert(err, Not(IsNil))
 }
 
 func (s *FilesystemSuite) TestSymlinkOpenWithRelativePath(c *C) {
@@ -1146,5 +1147,5 @@ func (s *FilesystemSuite) TestReadlinkWithRegularFile(c *C) {
 	c.Assert(err, IsNil)
 
 	_, err = fs.Readlink("file")
-	c.Assert(err, ErrorMatches, "readlink .+/file: invalid argument")
+	c.Assert(err, Not(IsNil))
 }

--- a/test/fs_suite.go
+++ b/test/fs_suite.go
@@ -1110,7 +1110,7 @@ func (s *FilesystemSuite) TestReadlinkWithAbsolutePath(c *C) {
 
 	oldname, err := fs.Readlink("dir/link")
 	c.Assert(err, IsNil)
-	c.Assert(oldname, Equals, "/dir/file")
+	c.Assert(oldname, Equals, expectedSymlinkTarget)
 }
 
 func (s *FilesystemSuite) TestReadlinkWithNonExistentOldname(c *C) {

--- a/test/fs_suite.go
+++ b/test/fs_suite.go
@@ -920,14 +920,8 @@ func (s *FilesystemSuite) TestWriteFile(c *C) {
 	c.Assert(f.Close(), IsNil)
 }
 
-type symlinker interface {
-	Filesystem
-	Symlink(oldname, newname string) error
-	Readlink(name string) (string, error)
-}
-
 func (s *FilesystemSuite) TestSymlink(c *C) {
-	fs, ok := s.FS.(symlinker)
+	fs, ok := s.FS.(Symlinker)
 	if !ok {
 		c.Skip("file system does not support symlinking")
 	}
@@ -945,7 +939,7 @@ func (s *FilesystemSuite) TestSymlink(c *C) {
 }
 
 func (s *FilesystemSuite) TestSymlinkToDir(c *C) {
-	fs, ok := s.FS.(symlinker)
+	fs, ok := s.FS.(Symlinker)
 	if !ok {
 		c.Skip("file system does not support symlinking")
 	}
@@ -964,7 +958,7 @@ func (s *FilesystemSuite) TestSymlinkToDir(c *C) {
 }
 
 func (s *FilesystemSuite) TestSymlinkWithNonExistentOldname(c *C) {
-	fs, ok := s.FS.(symlinker)
+	fs, ok := s.FS.(Symlinker)
 	if !ok {
 		c.Skip("file system does not support symlinking")
 	}
@@ -977,7 +971,7 @@ func (s *FilesystemSuite) TestSymlinkWithNonExistentOldname(c *C) {
 }
 
 func (s *FilesystemSuite) TestSymlinkWithExistingNewname(c *C) {
-	fs, ok := s.FS.(symlinker)
+	fs, ok := s.FS.(Symlinker)
 	if !ok {
 		c.Skip("file system does not support symlinking")
 	}
@@ -990,7 +984,7 @@ func (s *FilesystemSuite) TestSymlinkWithExistingNewname(c *C) {
 }
 
 func (s *FilesystemSuite) TestSymlinkOpenWithRelativePath(c *C) {
-	fs, ok := s.FS.(symlinker)
+	fs, ok := s.FS.(Symlinker)
 	if !ok {
 		c.Skip("file system does not support symlinking")
 	}
@@ -1014,7 +1008,7 @@ func (s *FilesystemSuite) TestSymlinkOpenWithRelativePath(c *C) {
 }
 
 func (s *FilesystemSuite) TestSymlinkOpenWithAbsolutePath(c *C) {
-	fs, ok := s.FS.(symlinker)
+	fs, ok := s.FS.(Symlinker)
 	if !ok {
 		c.Skip("file system does not support symlinking")
 	}
@@ -1038,7 +1032,7 @@ func (s *FilesystemSuite) TestSymlinkOpenWithAbsolutePath(c *C) {
 }
 
 func (s *FilesystemSuite) TestSymlinkReadDir(c *C) {
-	fs, ok := s.FS.(symlinker)
+	fs, ok := s.FS.(Symlinker)
 	if !ok {
 		c.Skip("file system does not support symlinking")
 	}
@@ -1062,7 +1056,7 @@ func (s *FilesystemSuite) TestSymlinkReadDir(c *C) {
 }
 
 func (s *FilesystemSuite) TestSymlinkRename(c *C) {
-	fs, ok := s.FS.(symlinker)
+	fs, ok := s.FS.(Symlinker)
 	if !ok {
 		c.Skip("file system does not support symlinking")
 	}
@@ -1078,7 +1072,7 @@ func (s *FilesystemSuite) TestSymlinkRename(c *C) {
 }
 
 func (s *FilesystemSuite) TestSymlinkRemove(c *C) {
-	fs, ok := s.FS.(symlinker)
+	fs, ok := s.FS.(Symlinker)
 	if !ok {
 		c.Skip("file system does not support symlinking")
 	}
@@ -1094,7 +1088,7 @@ func (s *FilesystemSuite) TestSymlinkRemove(c *C) {
 }
 
 func (s *FilesystemSuite) TestReadlinkWithRelativePath(c *C) {
-	fs, ok := s.FS.(symlinker)
+	fs, ok := s.FS.(Symlinker)
 	if !ok {
 		c.Skip("file system does not support symlinking")
 	}
@@ -1114,7 +1108,7 @@ func (s *FilesystemSuite) TestReadlinkWithRelativePath(c *C) {
 }
 
 func (s *FilesystemSuite) TestReadlinkWithAbsolutePath(c *C) {
-	fs, ok := s.FS.(symlinker)
+	fs, ok := s.FS.(Symlinker)
 	if !ok {
 		c.Skip("file system does not support symlinking")
 	}
@@ -1134,7 +1128,7 @@ func (s *FilesystemSuite) TestReadlinkWithAbsolutePath(c *C) {
 }
 
 func (s *FilesystemSuite) TestReadlinkWithNonExistentOldname(c *C) {
-	fs, ok := s.FS.(symlinker)
+	fs, ok := s.FS.(Symlinker)
 	if !ok {
 		c.Skip("file system does not support symlinking")
 	}
@@ -1148,7 +1142,7 @@ func (s *FilesystemSuite) TestReadlinkWithNonExistentOldname(c *C) {
 }
 
 func (s *FilesystemSuite) TestReadlinkWithNonExistentLink(c *C) {
-	fs, ok := s.FS.(symlinker)
+	fs, ok := s.FS.(Symlinker)
 	if !ok {
 		c.Skip("file system does not support symlinking")
 	}

--- a/test/fs_suite.go
+++ b/test/fs_suite.go
@@ -989,10 +989,7 @@ func (s *FilesystemSuite) TestSymlinkOpenWithRelativePath(c *C) {
 		c.Skip("file system does not support symlinking")
 	}
 
-	err := fs.MkdirAll("dir", 0755)
-	c.Assert(err, IsNil)
-
-	err = WriteFile(fs, "dir/file", []byte("foo"), 0644)
+	err := WriteFile(fs, "dir/file", []byte("foo"), 0644)
 	c.Assert(err, IsNil)
 
 	err = fs.Symlink("file", "dir/link")
@@ -1013,10 +1010,7 @@ func (s *FilesystemSuite) TestSymlinkOpenWithAbsolutePath(c *C) {
 		c.Skip("file system does not support symlinking")
 	}
 
-	err := fs.MkdirAll("dir", 0755)
-	c.Assert(err, IsNil)
-
-	err = WriteFile(fs, "dir/file", []byte("foo"), 0644)
+	err := WriteFile(fs, "dir/file", []byte("foo"), 0644)
 	c.Assert(err, IsNil)
 
 	err = fs.Symlink("/dir/file", "dir/link")
@@ -1037,10 +1031,7 @@ func (s *FilesystemSuite) TestSymlinkReadDir(c *C) {
 		c.Skip("file system does not support symlinking")
 	}
 
-	err := fs.MkdirAll("dir", 0755)
-	c.Assert(err, IsNil)
-
-	err = WriteFile(fs, "dir/file", []byte("foo"), 0644)
+	err := WriteFile(fs, "dir/file", []byte("foo"), 0644)
 	c.Assert(err, IsNil)
 
 	err = fs.Symlink("dir", "link")
@@ -1093,10 +1084,7 @@ func (s *FilesystemSuite) TestReadlinkWithRelativePath(c *C) {
 		c.Skip("file system does not support symlinking")
 	}
 
-	err := fs.MkdirAll("dir", 0755)
-	c.Assert(err, IsNil)
-
-	err = WriteFile(fs, "dir/file", nil, 0644)
+	err := WriteFile(fs, "dir/file", nil, 0644)
 	c.Assert(err, IsNil)
 
 	err = fs.Symlink("file", "dir/link")
@@ -1113,10 +1101,7 @@ func (s *FilesystemSuite) TestReadlinkWithAbsolutePath(c *C) {
 		c.Skip("file system does not support symlinking")
 	}
 
-	err := fs.MkdirAll("dir", 0755)
-	c.Assert(err, IsNil)
-
-	err = WriteFile(fs, "dir/file", nil, 0644)
+	err := WriteFile(fs, "dir/file", nil, 0644)
 	c.Assert(err, IsNil)
 
 	err = fs.Symlink("/dir/file", "dir/link")

--- a/test/fs_suite.go
+++ b/test/fs_suite.go
@@ -919,3 +919,190 @@ func (s *FilesystemSuite) TestWriteFile(c *C) {
 
 	c.Assert(f.Close(), IsNil)
 }
+
+type symlinker interface {
+	Filesystem
+	Symlink(oldname, newname string) error
+	Readlink(name string) (string, error)
+}
+
+func (s *FilesystemSuite) TestSymlink(c *C) {
+	fs, ok := s.FS.(symlinker)
+	if !ok {
+		c.Skip("file system does not support symlinking")
+	}
+
+	err := WriteFile(fs, "file", nil, 0644)
+	c.Assert(err, IsNil)
+
+	err = fs.Symlink("file", "link")
+	c.Assert(err, IsNil)
+
+	fi, err := fs.Stat("link")
+	c.Assert(err, IsNil)
+	c.Assert(fi.Name(), Equals, "link")
+	c.Assert(fi.Mode()&os.ModeSymlink, Not(Equals), 0)
+}
+
+func (s *FilesystemSuite) TestSymlinkToDir(c *C) {
+	fs, ok := s.FS.(symlinker)
+	if !ok {
+		c.Skip("file system does not support symlinking")
+	}
+
+	err := fs.MkdirAll("dir", 0755)
+	c.Assert(err, IsNil)
+
+	err = fs.Symlink("dir", "link")
+	c.Assert(err, IsNil)
+
+	fi, err := fs.Stat("link")
+	c.Assert(err, IsNil)
+	c.Assert(fi.Name(), Equals, "link")
+	c.Assert(fi.Mode()&os.ModeSymlink, Not(Equals), 0)
+	c.Assert(fi.IsDir(), Equals, true)
+}
+
+func (s *FilesystemSuite) TestSymlinkWithNonExistentOldname(c *C) {
+	fs, ok := s.FS.(symlinker)
+	if !ok {
+		c.Skip("file system does not support symlinking")
+	}
+
+	err := fs.Symlink("file", "link")
+	c.Assert(err, IsNil)
+
+	_, err = fs.Stat("link")
+	c.Assert(os.IsNotExist(err), Equals, true)
+}
+
+func (s *FilesystemSuite) TestSymlinkWithExistingNewname(c *C) {
+	fs, ok := s.FS.(symlinker)
+	if !ok {
+		c.Skip("file system does not support symlinking")
+	}
+
+	err := WriteFile(fs, "link", nil, 0644)
+	c.Assert(err, IsNil)
+
+	err = fs.Symlink("file", "link")
+	c.Assert(err, ErrorMatches, "symlink file .+/link: file exists")
+}
+
+func (s *FilesystemSuite) TestSymlinkOpen(c *C) {
+	fs, ok := s.FS.(symlinker)
+	if !ok {
+		c.Skip("file system does not support symlinking")
+	}
+
+	err := WriteFile(fs, "file", []byte("foo"), 0644)
+	c.Assert(err, IsNil)
+
+	err = fs.Symlink("file", "link")
+	c.Assert(err, IsNil)
+
+	f, err := s.FS.Open("link")
+	c.Assert(err, IsNil)
+
+	all, err := ioutil.ReadAll(f)
+	c.Assert(err, IsNil)
+	c.Assert(string(all), Equals, "foo")
+	c.Assert(f.Close(), IsNil)
+}
+
+func (s *FilesystemSuite) TestSymlinkReadDir(c *C) {
+	fs, ok := s.FS.(symlinker)
+	if !ok {
+		c.Skip("file system does not support symlinking")
+	}
+
+	err := fs.MkdirAll("dir", 0755)
+	c.Assert(err, IsNil)
+
+	err = WriteFile(fs, "dir/file", []byte("foo"), 0644)
+	c.Assert(err, IsNil)
+
+	err = fs.Symlink("dir", "link")
+	c.Assert(err, IsNil)
+
+	info, err := s.FS.ReadDir("link")
+	c.Assert(err, IsNil)
+	c.Assert(info, HasLen, 1)
+
+	c.Assert(info[0].Size(), Equals, int64(3))
+	c.Assert(info[0].IsDir(), Equals, false)
+	c.Assert(info[0].Name(), Equals, "file")
+}
+
+func (s *FilesystemSuite) TestSymlinkRename(c *C) {
+	fs, ok := s.FS.(symlinker)
+	if !ok {
+		c.Skip("file system does not support symlinking")
+	}
+
+	err := fs.Symlink("file", "link")
+	c.Assert(err, IsNil)
+
+	err = fs.Rename("link", "newlink")
+	c.Assert(err, IsNil)
+
+	_, err = fs.Readlink("newlink")
+	c.Assert(err, IsNil)
+}
+
+func (s *FilesystemSuite) TestSymlinkRemove(c *C) {
+	fs, ok := s.FS.(symlinker)
+	if !ok {
+		c.Skip("file system does not support symlinking")
+	}
+
+	err := fs.Symlink("file", "link")
+	c.Assert(err, IsNil)
+
+	err = fs.Remove("link")
+	c.Assert(err, IsNil)
+
+	_, err = fs.Readlink("link")
+	c.Assert(os.IsNotExist(err), Equals, true)
+}
+
+func (s *FilesystemSuite) TestReadlink(c *C) {
+	fs, ok := s.FS.(symlinker)
+	if !ok {
+		c.Skip("file system does not support symlinking")
+	}
+
+	err := WriteFile(fs, "file", nil, 0644)
+	c.Assert(err, IsNil)
+
+	err = fs.Symlink("file", "link")
+	c.Assert(err, IsNil)
+
+	oldname, err := fs.Readlink("link")
+	c.Assert(err, IsNil)
+	c.Assert(oldname, Equals, "file")
+}
+
+func (s *FilesystemSuite) TestReadlinkWithNonExistentOldname(c *C) {
+	fs, ok := s.FS.(symlinker)
+	if !ok {
+		c.Skip("file system does not support symlinking")
+	}
+
+	err := fs.Symlink("file", "link")
+	c.Assert(err, IsNil)
+
+	oldname, err := fs.Readlink("link")
+	c.Assert(err, IsNil)
+	c.Assert(oldname, Equals, "file")
+}
+
+func (s *FilesystemSuite) TestReadlinkWithNonExistentLink(c *C) {
+	fs, ok := s.FS.(symlinker)
+	if !ok {
+		c.Skip("file system does not support symlinking")
+	}
+
+	_, err := fs.Readlink("link")
+	c.Assert(os.IsNotExist(err), Equals, true)
+}

--- a/test/fs_suite_darwin.go
+++ b/test/fs_suite_darwin.go
@@ -1,0 +1,7 @@
+// +build !windows
+
+package test
+
+import "os"
+
+var customMode os.FileMode = 0755

--- a/test/fs_suite_darwin.go
+++ b/test/fs_suite_darwin.go
@@ -4,4 +4,7 @@ package test
 
 import "os"
 
-var customMode os.FileMode = 0755
+var (
+	customMode            os.FileMode = 0755
+	expectedSymlinkTarget             = "/dir/file"
+)

--- a/test/fs_suite_linux.go
+++ b/test/fs_suite_linux.go
@@ -4,4 +4,7 @@ package test
 
 import "os"
 
-var customMode os.FileMode = 0755
+var (
+	customMode            os.FileMode = 0755
+	expectedSymlinkTarget             = "/dir/file"
+)

--- a/test/fs_suite_windows.go
+++ b/test/fs_suite_windows.go
@@ -4,4 +4,7 @@ package test
 
 import "os"
 
-var customMode os.FileMode = 0666
+var (
+	customMode            os.FileMode = 0666
+	expectedSymlinkTarget             = "\\dir\\file"
+)


### PR DESCRIPTION
This PR addresses #28, but does not yet provide an implementation for the memory based filesystem.

- The `Symlinker` interface (I don't love this name) is a `Filesystem` with support for symlinking.
- Symlinks to directories are supported.
- Absolute and relative symlinks are supported, respecting the "base" directory of the filesystem.

This should be enough functionality to address src-d/go-git#358 for the common use-case of cloning to a regular filesystem.