### PR TITLE
*: Readlink and Symlink implementation

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -39,21 +39,14 @@ type Filesystem interface {
 	MkdirAll(filename string, perm os.FileMode) error
 	Join(elem ...string) string
 	Dir(path string) Filesystem
-	Base() string
-}
-
-// Symlinker is a Filesystem with support for creating symlinks.
-type Symlinker interface {
-	Filesystem
-
 	// Symlink creates a symbolic-link from link to target. target may be an
 	// absolute or relative path, and need not refer to an existing node.
 	// Parent directories of link are created as necessary.
 	Symlink(target, link string) error
-
 	// Readlink returns the target path of link. An error is returned if link is
 	// not a symbolic-link.
 	Readlink(link string) (string, error)
+	Base() string
 }
 
 // File implements io.Closer, io.Reader, io.Seeker, and io.Writer>

--- a/memfs/storage.go
+++ b/memfs/storage.go
@@ -22,14 +22,14 @@ func newStorage() *storage {
 }
 
 func (s *storage) Has(path string) bool {
-	path = filepath.Clean(path)
+	path = clean(path)
 
 	_, ok := s.files[path]
 	return ok
 }
 
 func (s *storage) New(path string, mode os.FileMode, flag int) (*file, error) {
-	path = filepath.Clean(path)
+	path = clean(path)
 	if s.Has(path) {
 		if !s.MustGet(path).mode.IsDir() {
 			return nil, fmt.Errorf("file already exists %q", path)
@@ -54,7 +54,7 @@ func (s *storage) New(path string, mode os.FileMode, flag int) (*file, error) {
 
 func (s *storage) createParent(path string, mode os.FileMode, f *file) error {
 	base := filepath.Dir(path)
-	base = filepath.Clean(base)
+	base = clean(base)
 	if f.Filename() == string(separator) {
 		return nil
 	}
@@ -72,7 +72,7 @@ func (s *storage) createParent(path string, mode os.FileMode, f *file) error {
 }
 
 func (s *storage) Children(path string) []*file {
-	path = filepath.Clean(path)
+	path = clean(path)
 
 	l := make([]*file, 0)
 	for _, f := range s.children[path] {
@@ -92,7 +92,7 @@ func (s *storage) MustGet(path string) *file {
 }
 
 func (s *storage) Get(path string) (*file, bool) {
-	path = filepath.Clean(path)
+	path = clean(path)
 	if !s.Has(path) {
 		return nil, false
 	}
@@ -102,8 +102,8 @@ func (s *storage) Get(path string) (*file, bool) {
 }
 
 func (s *storage) Rename(from, to string) error {
-	from = filepath.Clean(from)
-	to = filepath.Clean(to)
+	from = clean(from)
+	to = clean(to)
 
 	if !s.Has(from) {
 		return os.ErrNotExist
@@ -149,7 +149,7 @@ func (s *storage) move(from, to string) error {
 }
 
 func (s *storage) Remove(path string) error {
-	path = filepath.Clean(path)
+	path = clean(path)
 
 	f, has := s.Get(path)
 	if !has {
@@ -166,6 +166,10 @@ func (s *storage) Remove(path string) error {
 	delete(s.children[base], file)
 	delete(s.files, path)
 	return nil
+}
+
+func clean(path string) string {
+	return filepath.Clean(filepath.FromSlash(path))
 }
 
 type content struct {

--- a/osfs/os_posix.go
+++ b/osfs/os_posix.go
@@ -1,0 +1,15 @@
+// +build !windows
+
+package osfs
+
+import (
+	"os"
+
+	"gopkg.in/src-d/go-billy.v2"
+)
+
+// Stat returns the FileInfo structure describing file.
+func (fs *OS) Stat(filename string) (billy.FileInfo, error) {
+	fullpath := fs.absolutize(filename)
+	return os.Stat(fullpath)
+}

--- a/osfs/os_windows.go
+++ b/osfs/os_windows.go
@@ -1,0 +1,46 @@
+// +build windows
+
+package osfs
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/src-d/go-billy.v2"
+)
+
+// Stat returns the FileInfo structure describing file.
+func (fs *OS) Stat(filename string) (billy.FileInfo, error) {
+	// TODO: remove this in Go 1.9
+
+	fullpath := fs.absolutize(filename)
+
+	target, err := fs.Readlink(filename)
+	if err != nil {
+		return os.Stat(fullpath)
+	}
+
+	if !filepath.IsAbs(target) && !strings.HasPrefix(target, string(filepath.Separator)) {
+		target, _ = filepath.Rel(fs.base, fs.Join(filepath.Dir(fullpath), target))
+	}
+
+	fi, err := fs.Stat(target)
+	if err != nil {
+		return nil, err
+	}
+
+	return &fileInfo{
+		FileInfo: fi,
+		name:     filepath.Base(fullpath),
+	}, nil
+}
+
+type fileInfo struct {
+	os.FileInfo
+	name string
+}
+
+func (fi *fileInfo) Name() string {
+	return fi.name
+}

--- a/subdirfs/subdir_test.go
+++ b/subdirfs/subdir_test.go
@@ -38,17 +38,3 @@ func (s *FilesystemSuite) TearDownTest(c *C) {
 	err = stdos.RemoveAll(s.path)
 	c.Assert(err, IsNil)
 }
-
-func (s *FilesystemSuite) TestSymlinkWithNoUnderlyingSupport(c *C) {
-	s.cfs.(*subdirFs).underlying = nil
-
-	err := s.cfs.(billy.Symlinker).Symlink("foo", "bar")
-	c.Assert(err, Equals, ErrSymlinkNotSupported)
-}
-
-func (s *FilesystemSuite) TestReadlinkWithNoUnderlyingSupport(c *C) {
-	s.cfs.(*subdirFs).underlying = nil
-
-	_, err := s.cfs.(billy.Symlinker).Readlink("foo")
-	c.Assert(err, Equals, ErrSymlinkNotSupported)
-}

--- a/tmpoverlayfs/tmpfs.go
+++ b/tmpoverlayfs/tmpfs.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path"
 
+	"fmt"
+
 	"gopkg.in/src-d/go-billy.v2"
 	"gopkg.in/src-d/go-billy.v2/subdirfs"
 )
@@ -122,6 +124,24 @@ func (t *tmpFs) Remove(path string) error {
 	}
 
 	return t.fs.Remove(path)
+}
+
+// Symlink creates a symbolic-link from link to target. Using a temporal file
+// as target is not allowed.
+func (t *tmpFs) Symlink(target, link string) error {
+	if t.isTmpFile(target) {
+		return fmt.Errorf("links to temporal file are not supported")
+	}
+
+	if t.isTmpFile(link) {
+		return os.ErrExist
+	}
+
+	return t.fs.Symlink(target, link)
+}
+
+func (t *tmpFs) Readlink(link string) (string, error) {
+	return t.fs.Readlink(link)
 }
 
 func (t *tmpFs) Stat(path string) (billy.FileInfo, error) {

--- a/tmpoverlayfs/tmpfs_specific_test.go
+++ b/tmpoverlayfs/tmpfs_specific_test.go
@@ -131,6 +131,36 @@ func (s *SpecificFilesystemSuite) TestStatTempFile(c *C) {
 	c.Assert(fi, NotNil)
 }
 
+func (s *SpecificFilesystemSuite) TestSymlinkTmpFile(c *C) {
+	tmpFs := New(s.src, s.tmp)
+	c.Assert(tmpFs, NotNil)
+
+	f, err := tmpFs.TempFile("test-dir", "test-prefix")
+	c.Assert(err, IsNil)
+	c.Assert(f, NotNil)
+
+	tempFilename := f.Filename()
+	c.Assert(f.Close(), IsNil)
+
+	err = tmpFs.Symlink(tempFilename, "foo")
+	c.Assert(err, NotNil)
+}
+
+func (s *SpecificFilesystemSuite) TestSymlinkOverTmpFile(c *C) {
+	tmpFs := New(s.src, s.tmp)
+	c.Assert(tmpFs, NotNil)
+
+	f, err := tmpFs.TempFile("test-dir", "test-prefix")
+	c.Assert(err, IsNil)
+	c.Assert(f, NotNil)
+
+	tempFilename := f.Filename()
+	c.Assert(f.Close(), IsNil)
+
+	err = tmpFs.Symlink("foo", tempFilename)
+	c.Assert(err, NotNil)
+}
+
 func (s *SpecificFilesystemSuite) TestRenameFromTempFile(c *C) {
 	tmpFs := New(s.src, s.tmp)
 	c.Assert(tmpFs, NotNil)


### PR DESCRIPTION
The Symlinker interface has been merged with the original `Filesystem` interface.

At Windows, all the tests where `Stat` and links are involved were failing due to https://github.com/golang/go/issues/19870, to fix that, a specific `os.Stat` function was implemented resolving the link before stat the file.

Fixes https://github.com/src-d/go-billy/issues/28