### PR TITLE
memfs: better symlink support + *: lstat method

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -31,7 +31,12 @@ type Filesystem interface {
 	Create(filename string) (File, error)
 	Open(filename string) (File, error)
 	OpenFile(filename string, flag int, perm os.FileMode) (File, error)
+	// Stat returns a FileInfo describing the named file.
 	Stat(filename string) (FileInfo, error)
+	// Lstat returns a FileInfo describing the named file. If the file is a
+	// symbolic link, the returned FileInfo describes the symbolic link. Lstat
+	// makes no attempt to follow the link.
+	Lstat(filename string) (FileInfo, error)
 	ReadDir(path string) ([]FileInfo, error)
 	TempFile(dir, prefix string) (File, error)
 	Rename(from, to string) error

--- a/memfs/memory.go
+++ b/memfs/memory.go
@@ -114,6 +114,19 @@ func (fs *Memory) Stat(filename string) (billy.FileInfo, error) {
 	return fi, nil
 }
 
+func (fs *Memory) Lstat(filename string) (billy.FileInfo, error) {
+	fullpath := clean(fs.Join(fs.base, filename))
+	l, ok := fs.links[fullpath]
+	if !ok {
+		return fs.Stat(filename)
+	}
+
+	return &fileInfo{
+		name: filepath.Base(l.Name),
+		mode: 0777 | os.ModeSymlink,
+	}, nil
+}
+
 // ReadDir returns a list of billy.FileInfo in the given directory.
 func (fs *Memory) ReadDir(path string) ([]billy.FileInfo, error) {
 	path = fs.resolvePath(path)

--- a/osfs/os.go
+++ b/osfs/os.go
@@ -164,6 +164,11 @@ func (fs *OS) RemoveAll(path string) error {
 	return os.RemoveAll(fullpath)
 }
 
+func (fs *OS) Lstat(filename string) (billy.FileInfo, error) {
+	fullpath := fs.Join(fs.base, filename)
+	return os.Lstat(fullpath)
+}
+
 // Symlink imlements billy.Symlinker.Symlink.
 func (fs *OS) Symlink(target, link string) error {
 	target = filepath.FromSlash(target)

--- a/subdirfs/subdir.go
+++ b/subdirfs/subdir.go
@@ -93,6 +93,16 @@ func (s *subdirFs) Stat(filename string) (billy.FileInfo, error) {
 	return newFileInfo(filepath.Base(fullpath), fi), nil
 }
 
+func (s *subdirFs) Lstat(filename string) (billy.FileInfo, error) {
+	fullpath := s.underlyingPath(filename)
+	fi, err := s.underlying.Lstat(fullpath)
+	if err != nil {
+		return nil, err
+	}
+
+	return newFileInfo(filepath.Base(fullpath), fi), nil
+}
+
 func (s *subdirFs) ReadDir(path string) ([]billy.FileInfo, error) {
 	prefix := s.underlyingPath(path)
 	fis, err := s.underlying.ReadDir(prefix)

--- a/tmpoverlayfs/tmpfs.go
+++ b/tmpoverlayfs/tmpfs.go
@@ -152,6 +152,14 @@ func (t *tmpFs) Stat(path string) (billy.FileInfo, error) {
 	return t.fs.Stat(path)
 }
 
+func (t *tmpFs) Lstat(path string) (billy.FileInfo, error) {
+	if t.isTmpFile(path) {
+		return t.tmp.Lstat(path)
+	}
+
+	return t.fs.Lstat(path)
+}
+
 func (t *tmpFs) isTmpFile(p string) bool {
 	p = path.Clean(p)
 	_, ok := t.tempFiles[p]


### PR DESCRIPTION
This is a more natural and less confusing implementation of link at memfs, based on how a symlink works in os