### PR TITLE
helper: new polyfill helper, and mount and chroot simplification

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -121,7 +121,7 @@ type Chroot interface {
 	// Chroot returns a new filesystem from the same type where the new root is
 	// the given path. Files outside of the designated directory tree cannot be
 	// accessed.
-	Chroot(path string) (Basic, error)
+	Chroot(path string) (Filesystem, error)
 	// Root returns the root path of the filesystem.
 	Root() string
 }

--- a/helper/chroot/chroot_test.go
+++ b/helper/chroot/chroot_test.go
@@ -299,7 +299,7 @@ func (s *ChrootSuite) TestSymlinkWithBasic(c *C) {
 	m := &test.BasicMock{}
 
 	fs := New(m, "/foo")
-	err := fs.Symlink("", "")
+	err := fs.Symlink("qux", "bar")
 	c.Assert(err, Equals, billy.ErrNotSupported)
 }
 

--- a/helper/polyfill/polyfill.go
+++ b/helper/polyfill/polyfill.go
@@ -1,0 +1,100 @@
+package polyfill
+
+import (
+	"os"
+	"path/filepath"
+
+	"gopkg.in/src-d/go-billy.v3"
+)
+
+// Polyfill is a helper that implements all missing method from billy.Filesystem.
+type Polyfill struct {
+	billy.Basic
+	c capabilities
+}
+
+type capabilities struct{ tempfile, dir, symlink, chroot bool }
+
+// New creates a new filesystem wrapping up 'fs' the intercepts all the calls
+// made and errors if fs doesn't implement any of the billy interfaces.
+func New(fs billy.Basic) billy.Filesystem {
+	if original, ok := fs.(billy.Filesystem); ok {
+		return original
+	}
+
+	h := &Polyfill{Basic: fs}
+
+	_, h.c.tempfile = h.Basic.(billy.TempFile)
+	_, h.c.dir = h.Basic.(billy.Dir)
+	_, h.c.symlink = h.Basic.(billy.Symlink)
+	_, h.c.chroot = h.Basic.(billy.Chroot)
+	return h
+}
+
+func (h *Polyfill) TempFile(dir, prefix string) (billy.File, error) {
+	if !h.c.tempfile {
+		return nil, billy.ErrNotSupported
+	}
+
+	return h.Basic.(billy.TempFile).TempFile(dir, prefix)
+}
+
+func (h *Polyfill) ReadDir(path string) ([]os.FileInfo, error) {
+	if !h.c.dir {
+		return nil, billy.ErrNotSupported
+	}
+
+	return h.Basic.(billy.Dir).ReadDir(path)
+}
+
+func (h *Polyfill) MkdirAll(filename string, perm os.FileMode) error {
+	if !h.c.dir {
+		return billy.ErrNotSupported
+	}
+
+	return h.Basic.(billy.Dir).MkdirAll(filename, perm)
+}
+
+func (h *Polyfill) Symlink(target, link string) error {
+	if !h.c.symlink {
+		return billy.ErrNotSupported
+	}
+
+	return h.Basic.(billy.Symlink).Symlink(target, link)
+}
+
+func (h *Polyfill) Readlink(link string) (string, error) {
+	if !h.c.symlink {
+		return "", billy.ErrNotSupported
+	}
+
+	return h.Basic.(billy.Symlink).Readlink(link)
+}
+
+func (h *Polyfill) Lstat(path string) (os.FileInfo, error) {
+	if !h.c.symlink {
+		return nil, billy.ErrNotSupported
+	}
+
+	return h.Basic.(billy.Symlink).Lstat(path)
+}
+
+func (h *Polyfill) Chroot(path string) (billy.Filesystem, error) {
+	if !h.c.chroot {
+		return nil, billy.ErrNotSupported
+	}
+
+	return h.Basic.(billy.Chroot).Chroot(path)
+}
+
+func (h *Polyfill) Root() string {
+	if !h.c.chroot {
+		return string(filepath.Separator)
+	}
+
+	return h.Basic.(billy.Chroot).Root()
+}
+
+func (h *Polyfill) Underlying() billy.Basic {
+	return h.Basic
+}

--- a/helper/polyfill/polyfill_test.go
+++ b/helper/polyfill/polyfill_test.go
@@ -1,0 +1,63 @@
+package polyfill
+
+import (
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/src-d/go-billy.v3"
+	"gopkg.in/src-d/go-billy.v3/test"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+var _ = Suite(&PolyfillSuite{})
+
+type PolyfillSuite struct {
+	Helper     billy.Filesystem
+	Underlying billy.Filesystem
+}
+
+func (s *PolyfillSuite) SetUpTest(c *C) {
+	s.Helper = New(&test.BasicMock{})
+}
+
+func (s *PolyfillSuite) TestTempFile(c *C) {
+	_, err := s.Helper.TempFile("", "")
+	c.Assert(err, Equals, billy.ErrNotSupported)
+}
+
+func (s *PolyfillSuite) TestReadDir(c *C) {
+	_, err := s.Helper.ReadDir("")
+	c.Assert(err, Equals, billy.ErrNotSupported)
+}
+
+func (s *PolyfillSuite) TestMkdirAll(c *C) {
+	err := s.Helper.MkdirAll("", 0)
+	c.Assert(err, Equals, billy.ErrNotSupported)
+}
+
+func (s *PolyfillSuite) TestSymlink(c *C) {
+	err := s.Helper.Symlink("", "")
+	c.Assert(err, Equals, billy.ErrNotSupported)
+}
+
+func (s *PolyfillSuite) TestReadlink(c *C) {
+	_, err := s.Helper.Readlink("")
+	c.Assert(err, Equals, billy.ErrNotSupported)
+}
+
+func (s *PolyfillSuite) TestLstat(c *C) {
+	_, err := s.Helper.Lstat("")
+	c.Assert(err, Equals, billy.ErrNotSupported)
+}
+
+func (s *PolyfillSuite) TestChroot(c *C) {
+	_, err := s.Helper.Chroot("")
+	c.Assert(err, Equals, billy.ErrNotSupported)
+}
+
+func (s *PolyfillSuite) TestRoot(c *C) {
+	c.Assert(s.Helper.Root(), Equals, string(filepath.Separator))
+}


### PR DESCRIPTION
After implementing the approach of split interfaces, I found a lot of frictions. So I decided to instead of work with partial implementation, help to the a Filesystem be filled with the missing method, to much the interface.

The previous approach fails at implementation like go-billy-siva, where has a very strong limitations, such not being able to read on file where are you writing, rename not being supported, etc. This ends with the idea that could be useful assert by interface if a fs fits the requirements, since the limitations transcend the interface limits. 

