### PR TITLE
chroot: allow Symlinks cross boundary

### DIFF
--- a/helper/chroot/chroot.go
+++ b/helper/chroot/chroot.go
@@ -169,27 +169,12 @@ func (fs *ChrootHelper) Symlink(target, link string) error {
 		target = filepath.Clean(filepath.FromSlash(target))
 	}
 
-	if fs.isTargetOutBounders(link, target) {
-		return billy.ErrCrossedBoundary
-	}
-
 	link, err := fs.underlyingPath(link)
 	if err != nil {
 		return err
 	}
 
 	return fs.underlying.(billy.Symlink).Symlink(target, link)
-}
-
-func (fs *ChrootHelper) isTargetOutBounders(link, target string) bool {
-	fulllink := fs.Join(fs.base, link)
-	fullpath := fs.Join(filepath.Dir(fulllink), target)
-	target, err := filepath.Rel(fs.base, fullpath)
-	if err != nil {
-		return true
-	}
-
-	return isCrossBoundaries(target)
 }
 
 func (fs *ChrootHelper) Readlink(link string) (string, error) {

--- a/test/fs.go
+++ b/test/fs.go
@@ -104,8 +104,14 @@ func (s *FilesystemSuite) TestSymlinkWithChrootBasic(c *C) {
 
 func (s *FilesystemSuite) TestSymlinkWithChrootCrossBounders(c *C) {
 	qux, _ := s.FS.Chroot("/qux")
-	err := qux.(Filesystem).Symlink("../../file", "qux/link")
-	c.Assert(err, Equals, ErrCrossedBoundary)
+	util.WriteFile(s.FS, "file", []byte("foo"), customMode)
+
+	err := qux.Symlink("../../file", "qux/link")
+	c.Assert(err, Equals, nil)
+
+	fi, err := qux.Stat("qux/link")
+	c.Assert(fi, NotNil)
+	c.Assert(err, Equals, nil)
 }
 
 func (s *FilesystemSuite) TestReadDirWithLink(c *C) {


### PR DESCRIPTION
This PR allows the creation of links where the target is outside of the chroot.  The downside is that the file can be read it, not being a strict chroot anymore.

Fixes https://github.com/src-d/go-git/issues/445
