### PR TITLE
fs: add `Truncate` method to `File` interface

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -140,4 +140,6 @@ type File interface {
 	Lock() error
 	// Unlock unlocks the file.
 	Unlock() error
+	// Truncate the file.
+	Truncate(size int64) error
 }

--- a/memfs/memory.go
+++ b/memfs/memory.go
@@ -273,7 +273,10 @@ func (f *file) Close() error {
 func (f *file) Truncate(size int64) error {
 	if size < int64(len(f.content.bytes)) {
 		f.content.bytes = f.content.bytes[:size]
+	} else if more := int(size)-len(f.content.bytes); more > 0 {
+		f.content.bytes = append(f.content.bytes, make([]byte, more)...)
 	}
+
 	return nil
 }
 

--- a/memfs/memory.go
+++ b/memfs/memory.go
@@ -270,6 +270,13 @@ func (f *file) Close() error {
 	return nil
 }
 
+func (f *file) Truncate(size int64) error {
+	if size < int64(len(f.content.bytes)) {
+		f.content.bytes = f.content.bytes[:size]
+	}
+	return nil
+}
+
 func (f *file) Duplicate(filename string, mode os.FileMode, flag int) billy.File {
 	new := &file{
 		name:    filename,

--- a/test/basic.go
+++ b/test/basic.go
@@ -562,3 +562,22 @@ func (s *BasicSuite) TestWriteFile(c *C) {
 
 	c.Assert(f.Close(), IsNil)
 }
+
+func (s *BasicSuite) TestTruncate(c *C) {
+	f, err := s.FS.Create("foo")
+	c.Assert(err, IsNil)
+
+	for _, sz := range []int64{4, 7, 2, 30, 0, 1} {
+		err = f.Truncate(sz)
+		c.Assert(err, IsNil)
+
+		bs, err := ioutil.ReadAll(f)
+		c.Assert(err, IsNil)
+		c.Assert(len(bs), Equals, int(sz))
+
+		_, err = f.Seek(0, io.SeekStart)
+		c.Assert(err, IsNil)
+	}
+
+	c.Assert(f.Close(), IsNil)
+}

--- a/test/mock.go
+++ b/test/mock.go
@@ -130,3 +130,7 @@ func (*FileMock) Lock() error {
 func (*FileMock) Unlock() error {
 	return nil
 }
+
+func (*FileMock) Truncate(size int64) error {
+	return nil
+}


### PR DESCRIPTION
cc: @mcuadros -- we needed this for the fast-forward fetch implementation.

This code is written by @taruti.