### PR TITLE
ci: test Go 1.9.x and 1.10.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
 language: go
 
 go:
-    - 1.9
+  - 1.9.x
+  - 1.10.x
 
 go_import_path: gopkg.in/src-d/go-billy.v4
-
-matrix:
-    allow_failures:
-        - go: tip
 
 install:
   - go get -v -t ./...


### PR DESCRIPTION
More info:
https://github.com/src-d/guide/blob/master/engineering/conventions-go.md

Signed-off-by: Santiago M. Mola <santi@mola.io>