### PR TITLE
Add Capability function to query fs capabilities

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -13,6 +13,28 @@ var (
 	ErrCrossedBoundary = errors.New("chroot boundary crossed")
 )
 
+// Capability holds the supported features of a filesystem.
+type Capability uint64
+
+const (
+	// CapWrite means that the fs is writable.
+	CapWrite Capability = 1 << iota
+	// CapRead means that the fs is readable.
+	CapRead
+	// CapReadAndWrite is the ability to open a file in read and write mode.
+	CapReadAndWrite
+	// CapSeek means it is able to move position inside the file.
+	CapSeek
+	// CapTruncate means that a file can be truncated.
+	CapTruncate
+	// CapLock is the ability to lock a file.
+	CapLock
+
+	// CapAll lists all capable features.
+	CapAll Capability = CapWrite | CapRead | CapReadAndWrite |
+		CapSeek | CapTruncate | CapLock
+)
+
 // Filesystem abstract the operations in a storage-agnostic interface.
 // Each method implementation mimics the behavior of the equivalent functions
 // at the os package from the standard library.
@@ -142,4 +164,21 @@ type File interface {
 	Unlock() error
 	// Truncate the file.
 	Truncate(size int64) error
+}
+
+// Capable interface can return the available features of a filesystem.
+type Capable interface {
+	// Capabilities returns the capabilities of a filesystem in bit flags.
+	Capabilities() Capability
+}
+
+// Capabilities returns the features supported by a filesystem. If the FS
+// does not implement Capable interface it returns all features.
+func Capabilities(fs Basic) Capability {
+	capable, ok := fs.(Capable)
+	if !ok {
+		return CapAll
+	}
+
+	return capable.Capabilities()
 }

--- a/helper/chroot/chroot.go
+++ b/helper/chroot/chroot.go
@@ -217,6 +217,11 @@ func (fs *ChrootHelper) Underlying() billy.Basic {
 	return fs.underlying
 }
 
+// Capabilities implements the Capable interface.
+func (fs *ChrootHelper) Capabilities() billy.Capability {
+	return billy.Capabilities(fs.underlying)
+}
+
 type file struct {
 	billy.File
 	name string

--- a/helper/mount/mount.go
+++ b/helper/mount/mount.go
@@ -167,6 +167,11 @@ func (h *Mount) Underlying() billy.Basic {
 	return h.underlying
 }
 
+// Capabilities implements the Capable interface.
+func (fs *Mount) Capabilities() billy.Capability {
+	return billy.Capabilities(fs.underlying)
+}
+
 func (fs *Mount) getBasicAndPath(path string) (billy.Basic, string) {
 	path = cleanPath(path)
 	if !fs.isMountpoint(path) {

--- a/helper/polyfill/polyfill.go
+++ b/helper/polyfill/polyfill.go
@@ -98,3 +98,8 @@ func (h *Polyfill) Root() string {
 func (h *Polyfill) Underlying() billy.Basic {
 	return h.Basic
 }
+
+// Capabilities implements the Capable interface.
+func (h *Polyfill) Capabilities() billy.Capability {
+	return billy.Capabilities(h.Basic)
+}

--- a/memfs/memory.go
+++ b/memfs/memory.go
@@ -190,6 +190,15 @@ func (fs *Memory) Readlink(link string) (string, error) {
 	return string(f.content.bytes), nil
 }
 
+// Capabilities implements the Capable interface.
+func (fs *Memory) Capabilities() billy.Capability {
+	return billy.CapWrite |
+		billy.CapRead |
+		billy.CapReadAndWrite |
+		billy.CapSeek |
+		billy.CapTruncate
+}
+
 type file struct {
 	name     string
 	content  *content
@@ -273,7 +282,7 @@ func (f *file) Close() error {
 func (f *file) Truncate(size int64) error {
 	if size < int64(len(f.content.bytes)) {
 		f.content.bytes = f.content.bytes[:size]
-	} else if more := int(size)-len(f.content.bytes); more > 0 {
+	} else if more := int(size) - len(f.content.bytes); more > 0 {
 		f.content.bytes = append(f.content.bytes, make([]byte, more)...)
 	}
 

--- a/memfs/memory_test.go
+++ b/memfs/memory_test.go
@@ -3,6 +3,7 @@ package memfs
 import (
 	"testing"
 
+	"gopkg.in/src-d/go-billy.v4"
 	"gopkg.in/src-d/go-billy.v4/test"
 
 	. "gopkg.in/check.v1"
@@ -19,4 +20,12 @@ var _ = Suite(&MemorySuite{})
 
 func (s *MemorySuite) SetUpTest(c *C) {
 	s.FilesystemSuite = test.NewFilesystemSuite(New())
+}
+
+func (s *MemorySuite) TestCapabilities(c *C) {
+	_, ok := s.FS.(billy.Capable)
+	c.Assert(ok, Equals, true)
+
+	caps := billy.Capabilities(s.FS)
+	c.Assert(caps, Equals, billy.CapAll&^billy.CapLock)
 }

--- a/osfs/os.go
+++ b/osfs/os.go
@@ -127,6 +127,11 @@ func (fs *OS) Readlink(link string) (string, error) {
 	return os.Readlink(link)
 }
 
+// Capabilities implements the Capable interface.
+func (fs *OS) Capabilities() billy.Capability {
+	return billy.CapAll
+}
+
 // file is a wrapper for an os.File which adds support for file locking.
 type file struct {
 	*os.File

--- a/osfs/os_test.go
+++ b/osfs/os_test.go
@@ -6,8 +6,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	. "gopkg.in/check.v1"
+	"gopkg.in/src-d/go-billy.v4"
 	"gopkg.in/src-d/go-billy.v4/test"
+
+	. "gopkg.in/check.v1"
 )
 
 func Test(t *testing.T) { TestingT(t) }
@@ -35,4 +37,12 @@ func (s *OSSuite) TestOpenDoesNotCreateDir(c *C) {
 
 	_, err = os.Stat(filepath.Join(s.path, "dir"))
 	c.Assert(os.IsNotExist(err), Equals, true)
+}
+
+func (s *OSSuite) TestCapabilities(c *C) {
+	_, ok := s.FS.(billy.Capable)
+	c.Assert(ok, Equals, true)
+
+	caps := billy.Capabilities(s.FS)
+	c.Assert(caps, Equals, billy.CapAll)
 }


### PR DESCRIPTION
This adds the Capable interface that can be implemented in filesystems
to return the features suported by it. This first iteration has the
following capablities:

* CapWrite
* CapRead
* CapReadAndWrite
* CapSeek
* CapTruncate
* CapLock

`billy.Capablilities(fs)` can be used to query a fs. The capabilities
are implemented as bit flags. If a filesystem does not implement `Capable`
interface then all capabilities will be returned as fall back.
