### PR TITLE
readme: fix a broken sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # go-billy [![GoDoc](https://godoc.org/gopkg.in/src-d/go-billy.v4?status.svg)](https://godoc.org/gopkg.in/src-d/go-billy.v4) [![Build Status](https://travis-ci.org/src-d/go-billy.svg)](https://travis-ci.org/src-d/go-billy) [![Build status](https://ci.appveyor.com/api/projects/status/vx2qn6vlakbi724t?svg=true)](https://ci.appveyor.com/project/mcuadros/go-billy) [![codecov](https://codecov.io/gh/src-d/go-billy/branch/master/graph/badge.svg)](https://codecov.io/gh/src-d/go-billy)
 
 The missing interface filesystem abstraction for Go.
-Billy implements an interface based on the `os` standard library, allowing to develop applications without dependency on the underlying storage. Make virtually free implement an mocks and testing over filesystem operations.
+Billy implements an interface based on the `os` standard library, allowing to develop applications without dependency on the underlying storage. Makes it virtually free to implement mocks and testing over filesystem operations.
 
 Billy was born as part of [src-d/go-git](https://github.com/src-d/go-git) project.
 


### PR DESCRIPTION
Fix a sentence that makes no sense,
to allay readers' inconvenience.