### PR TITLE
Enables building on Solaris

### DIFF
--- a/osfs/os_posix.go
+++ b/osfs/os_posix.go
@@ -3,19 +3,19 @@
 package osfs
 
 import (
-	"syscall"
+	"golang.org/x/sys/unix"
 )
 
 func (f *file) Lock() error {
 	f.m.Lock()
 	defer f.m.Unlock()
 
-	return syscall.Flock(int(f.File.Fd()), syscall.LOCK_EX)
+	return unix.Flock(int(f.File.Fd()), unix.LOCK_EX)
 }
 
 func (f *file) Unlock() error {
 	f.m.Lock()
 	defer f.m.Unlock()
 
-	return syscall.Flock(int(f.File.Fd()), syscall.LOCK_UN)
+	return unix.Flock(int(f.File.Fd()), unix.LOCK_UN)
 }


### PR DESCRIPTION
Using `golang.org/x/sys/unix` instead of `syscall` in `osfs/os_posix.go` makes this project buildable on OpenIndiana 18.04 (OpenSolaris), most probably on Solaris too. See: https://github.com/golang/go/issues/11113