### PR TITLE
memfs: return error when using negative offsets

### DIFF
--- a/memfs/memory_test.go
+++ b/memfs/memory_test.go
@@ -1,6 +1,7 @@
 package memfs
 
 import (
+	"io"
 	"testing"
 
 	"gopkg.in/src-d/go-billy.v4"
@@ -28,4 +29,18 @@ func (s *MemorySuite) TestCapabilities(c *C) {
 
 	caps := billy.Capabilities(s.FS)
 	c.Assert(caps, Equals, billy.DefaultCapabilities&^billy.LockCapability)
+}
+
+func (s *MemorySuite) TestNegativeOffsets(c *C) {
+	f, err := s.FS.Create("negative")
+	c.Assert(err, IsNil)
+
+	buf := make([]byte, 100)
+	_, err = f.ReadAt(buf, -100)
+	c.Assert(err, ErrorMatches, "readat negative: negative offset")
+
+	_, err = f.Seek(-100, io.SeekCurrent)
+	c.Assert(err, IsNil)
+	_, err = f.Write(buf)
+	c.Assert(err, ErrorMatches, "writeat negative: negative offset")
 }


### PR DESCRIPTION
Same error as in go library:

https://github.com/golang/go/commit/a5999b7b81b9dc875cc635e1b089d768ddd41a8c
