### PR TITLE
Travis-ci: added support for ppc64le & updated go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: go
 
+arch:
+  - AMD64
+  - ppc64le
+
 go:
-  - 1.12.x
-  - 1.13.x
+  - 1.14.x
+  - 1.15.x
 
 go_import_path: gopkg.in/src-d/go-billy.v4
 


### PR DESCRIPTION
Signed-off-by: Devendranath Thadi <devendranath.thadi3@gmail.com>

Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.