### PR TITLE
Use perm passed to OS.MkdirAll

### DIFF
--- a/osfs/os.go
+++ b/osfs/os.go
@@ -76,7 +76,7 @@ func (fs *OS) Rename(from, to string) error {
 }
 
 func (fs *OS) MkdirAll(path string, perm os.FileMode) error {
-	return os.MkdirAll(path, defaultDirectoryMode)
+	return os.MkdirAll(path, perm)
 }
 
 func (fs *OS) Open(filename string) (billy.File, error) {


### PR DESCRIPTION
Previously, a perm passed to OS.MkdirAll was ignored, and
defaultDirectoryMode was used instad. Now, the perm passed to MkdirAll
is used.